### PR TITLE
Fix typo, add checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,12 @@
+name: Check
+
+on: push
+
+jobs:
+    gprbuild:
+        name: gprbuild
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - name: gprbuild
+              run: docker run -v $PWD:/app componolit/ci:gnat-community-2019 /bin/sh -c "gprbuild -P /app/style.gpr"

--- a/style.gpr
+++ b/style.gpr
@@ -29,4 +29,4 @@ is
      ,"-gnatyx"    -- check extra parentheses around conditionals
    );
 
-end Style
+end Style;


### PR DESCRIPTION
To prevent pushing a broken grp file in the future I added a check that fails if the gpr contains errors.